### PR TITLE
docs: fix README doc links and update patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ npm install reactx@alpha
 
 ## Documentation
 
-- [Creating State](docs/creating-state.md) — classes, computed values, nested and per-key state
-- [Components](docs/components.md) — reading state, scoping re-renders, async patterns
-- [Services](docs/services.md) — infrastructure, platform abstraction, testing
+- [Architecture](docs/architecture.md) — the services → state → components → ui-components layering
+- [Patterns](docs/patterns.md) — composing state, services, invariants, subscriptions
 
 ## Quick example
 
@@ -45,6 +44,24 @@ function App() {
 ```
 
 `reactive()` makes the class instance lazily observable. Components re-render only when the properties they actually read change — no providers, no hooks, no boilerplate. Build your application state and logic with an objected oriented mindset and derive a functional UI from it.
+
+## Using with AI coding agents
+
+Copy this into your `CLAUDE.md` (or equivalent agent instructions file):
+
+```markdown
+## Services, State and UI
+
+**Setup**: `reactive(new AppState(services))` makes the instance observable. The Vite plugin auto-wraps all exported React components as observers. Wire to React with `createContext` + a `useXxx` hook that throws on missing provider.
+
+**`*State` classes** own observable state (properties), computed values (getters), and mutations (methods). No special APIs — plain OO.
+
+**`*Service` classes** own side effects (HTTP, storage, timers). Inject via constructor; define an interface so tests can swap in lightweight implementations without mocking.
+
+**Components** read from context and call methods directly. No special hooks needed for reading state.
+
+**Invariants**: When a value is nullable at the top but guaranteed present in a subtree, expose a getter that throws. Components in that subtree use it without null checks — a violation is a programming error, not a runtime condition.
+```
 
 ## Setup
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -149,84 +149,17 @@ const app = reactive(new AppState(testServices));
 
 ---
 
-## Dependency injection with tsyringe
-
-For larger apps, [tsyringe](https://github.com/microsoft/tsyringe) wires services automatically via decorators instead of a hand-rolled `Services` object. Register implementations once; the container resolves the full graph.
-
-Use abstract classes as service contracts — interfaces are erased at runtime, but abstract classes are preserved, so tsyringe can resolve them via `reflect-metadata` without explicit tokens.
-
-```ts
-// services/http.ts
-export abstract class Http {
-  abstract get<T>(url: string): Promise<T>
-  abstract post<T>(url: string, body: unknown): Promise<T>
-}
-
-// services/persistence.ts
-export abstract class Persistence {
-  abstract get<T>(key: string): T | null
-  abstract set<T>(key: string, value: T): void
-  abstract remove(key: string): void
-}
-```
-
-```ts
-// services/browser.ts
-@injectable()
-export class BrowserHttp extends Http {
-  async get<T>(url: string) { ... }
-  async post<T>(url: string, body: unknown) { ... }
-}
-
-@injectable()
-export class BrowserPersistence extends Persistence {
-  get<T>(key: string) { ... }
-  set<T>(key: string, value: T) { ... }
-  remove(key: string) { ... }
-}
-```
-
-```ts
-// container.ts
-container.registerSingleton(Http, BrowserHttp)
-container.registerSingleton(Persistence, BrowserPersistence)
-```
-
-```ts
-// app.ts
-@singleton()
-class AppState {
-  constructor(
-    private http: Http,
-    private persistence: Persistence,
-  ) {}
-}
-
-export const app = reactive(container.resolve(AppState))
-```
-
-**Testing** — register in-memory implementations before resolving:
-
-```ts
-container.registerInstance(Http, { get: async () => fixtureData, post: async () => fixtureData })
-container.registerInstance(Persistence, new InMemoryPersistence())
-
-const app = reactive(container.resolve(AppState))
-```
-
----
-
 ## Invariants
 
 Some state is nullable at the top level but guaranteed non-null in certain contexts — an authenticated user, a loaded resource, a selected item. Rather than threading null checks through every component that can only ever render when the value exists, define a getter that throws if the invariant is violated:
 
 ```ts
 class AppState {
-  user: User | null = null
+  user: User | null = null;
 
   get authenticatedUser(): User {
-    if (!this.user) throw new Error("No authenticated user")
-    return this.user
+    if (!this.user) throw new Error("No authenticated user");
+    return this.user;
   }
 }
 ```
@@ -235,7 +168,7 @@ Components rendered inside an authenticated route use the invariant directly —
 
 ```tsx
 function Profile() {
-  return <div>{app.authenticatedUser.name}</div>
+  return <div>{app.authenticatedUser.name}</div>;
 }
 ```
 


### PR DESCRIPTION
Point the Documentation section at the docs that actually exist (architecture.md, patterns.md) instead of the missing creating-state, components, and services files.